### PR TITLE
fix build for vmhgfs when the kernel is not compiled with CONFIG_UIDGID_...

### DIFF
--- a/patches/vmhgfs/vmhgfs-uid-gid-kernel-3.12-tools-9.6.1.patch
+++ b/patches/vmhgfs/vmhgfs-uid-gid-kernel-3.12-tools-9.6.1.patch
@@ -128,7 +128,7 @@ diff -ur vmhgfs-only.orig/shared/compat_cred.h vmhgfs-only/shared/compat_cred.h
  #define current_fsgid() (current->fsgid)
  #endif
 
-+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 12, 0)
++#ifdef CONFIG_UIDGID_STRICT_TYPE_CHECKS
 +#define CURRENT_FSUID() (__kuid_val(current_fsuid()))
 +#define CURRENT_FSGID() (__kgid_val(current_fsgid()))
 +#define CURRENT_UID() (__kuid_val(current_uid()))


### PR DESCRIPTION
...STRICT_TYPE_CHECKS set

When CONFIG_UIDGID_STRICT_TYPE_CHECKS is set, uid_t et al is a structure
with the only one member, val. This is probably to prevent uid_t from
mixing with gid_t accidentally. When this is not set however, they are
both just an unsigned int.

Ubuntu probably has this kernel build option set, while Arch Linux does
not, leading vmhgfs to not compile.
