### PR TITLE
Add patch for hgfs on el7 kernel 3.10.0

### DIFF
--- a/patch-module.sh
+++ b/patch-module.sh
@@ -25,7 +25,7 @@ if [[ ! -d "${patchdir}" ]]; then
   exit 3
 fi
 
-patches="$(find ${patchdir} -type f -size +1 -regextype posix-extended -iregex '.*\.(patch|diff)')"
+patches="$(find ${patchdir} -type f -size +1c -regextype posix-extended -iregex '.*\.(patch|diff)')"
 
 if [[ -z "${patches}" ]]; then
   echo $0: Error: no patches found in ${patchdir} >&2

--- a/patch-modules.sh
+++ b/patch-modules.sh
@@ -7,7 +7,7 @@ readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 modules="$(find ${SCRIPT_DIR}/patches -mindepth 1 -maxdepth 1 -type d)"
 
 for module in ${modules}; do
-  patches="$(find ${module} -type f -size +1 -regextype posix-extended -iregex '.*\.(patch|diff)')"
+  patches="$(find ${module} -type f -size +1c -regextype posix-extended -iregex '.*\.(patch|diff)')"
 
   if [[ "${patches}" ]]; then
     "${SCRIPT_DIR}/patch-module.sh" "$module"

--- a/patches/vmhgfs/compat_dcache.h.patch
+++ b/patches/vmhgfs/compat_dcache.h.patch
@@ -1,0 +1,11 @@
+--- vmhgfs-only.orig/shared/compat_dcache.h 2014-08-15 13:27:54.893517402 -0700
++++ vmhgfs-only.orig/shared/compat_dcache.h 2014-08-15 13:28:13.218998756 -0700
+@@ -51,7 +51,7 @@
+ /*
+  * d_count field was removed in 3.11.0.
+  */
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 11, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
+ #define compat_d_count(dentry) d_count(dentry)
+ #elif LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 38)
+ #define compat_d_count(dentry) dentry->d_count


### PR DESCRIPTION
This pull request adds support for el7 (RHEL7 & CentOS7) which uses kernel 3.10 with backported patches, instead of 3.11.

It also adjusts the find commands a little so that they pick up this new patch correctly.
