### PR TITLE
HGFS: smp_mb__before_clear_bit missing in 3.18

### DIFF
--- a/patches/vmhgfs/vmhgfs-smp_mb_before_clear_bit-3.18-tools-9.9.0.patch
+++ b/patches/vmhgfs/vmhgfs-smp_mb_before_clear_bit-3.18-tools-9.9.0.patch
@@ -1,0 +1,21 @@
+--- vmhgfs-only/page.c	2014-11-18 02:07:13.000000000 +0000
++++ vmhgfs-only/page.c	2014-12-24 23:50:17.868774796 +0000
+@@ -1678,9 +1678,18 @@
+       LOG(6, (KERN_WARNING "VMware Hgfs: %s: Invalid unlock attempted\n", __func__));
+       return;
+    }
++#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 18, 0)
+    smp_mb__before_clear_bit();
++#else
++   smp_mb__before_atomic();
++#endif
+    clear_bit(PG_BUSY, &req->wb_flags);
++#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 18, 0)
+    smp_mb__after_clear_bit();
++#else
++   smp_mb__after_atomic();
++#endif
++
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 13)
+    wake_up_bit(&req->wb_flags, PG_BUSY);
+ #else


### PR DESCRIPTION
Fixes compile error on 3.18

vmhgfs-only/page.c:1681:4: error: implicit declaration of function ‘smp_mb__before_clear_bit’ 

Disappeared in 3.18, but already in 3.17 an alternative name is given:

http://lxr.free-electrons.com/source/include/linux/bitops.h?v=3.17#L40
