### PR TITLE
Patches to build and run vmhgfs on 3.18.1

### DIFF
--- a/patches/vmhgfs/vmhgfs-d_alias-kernel-3.18.1-tools-9.6.1.patch
+++ b/patches/vmhgfs/vmhgfs-d_alias-kernel-3.18.1-tools-9.6.1.patch
@@ -1,0 +1,11 @@
+--- vmhgfs-only/inode.c.orig	2014-12-31 16:04:41.000000000 +0000
++++ vmhgfs-only/inode.c	2014-12-31 16:49:00.597010246 +0000
+@@ -1893,7 +1893,7 @@
+                            p,
+ #endif
+                            &inode->i_dentry,
+-                           d_alias) {
++                           d_u.d_alias) {
+          int dcount = compat_d_count(dentry);
+          if (dcount) {
+             LOG(4, ("Found %s %d \n", dentry->d_name.name, dcount));

--- a/patches/vmhgfs/vmhgfs-d_set_type-kernel-3.18.1-tools-9.6.1.patch
+++ b/patches/vmhgfs/vmhgfs-d_set_type-kernel-3.18.1-tools-9.6.1.patch
@@ -1,0 +1,10 @@
+--- ../vmhgfs-only/filesystem.c	2015-01-01 05:58:21.489892698 +0000
++++ vmhgfs-only/filesystem.c	2015-01-01 13:53:35.036611203 +0000
+@@ -408,6 +408,7 @@
+    HgfsChangeFileAttributes(tempRootDentry->d_inode, &rootDentryAttr);
+    HgfsDentryAgeReset(tempRootDentry);
+    tempRootDentry->d_op = &HgfsDentryOperations;
++   __d_set_type(tempRootDentry, DCACHE_DIRECTORY_TYPE);
+ 
+    *rootDentry = tempRootDentry;
+    result = 0;

--- a/patches/vmhgfs/vmhgfs-rename_deprecated-kernel-3.18.1-tools-9.6.1.patch
+++ b/patches/vmhgfs/vmhgfs-rename_deprecated-kernel-3.18.1-tools-9.6.1.patch
@@ -1,0 +1,17 @@
+--- vmhgfs-only.orig/shared/vm_assert.h	2013-10-09 05:31:01.000000000 +0000
++++ vmhgfs-only/shared/vm_assert.h	2014-12-31 15:18:02.847753652 +0000
+@@ -251,12 +251,12 @@
+ #define LOG_ONCE(_s) DO_ONCE(Log _s)
+ 
+ #ifdef VMX86_DEVEL
+-   #define DEPRECATED(_fix) DO_ONCE(                                     \
++   #define VMW_DEPRECATED(_fix) DO_ONCE(                                     \
+                                Warning("%s:%d: %s is DEPRECATED. %s\n",  \
+                                        __FILE__, __LINE__, __FUNCTION__, \
+                                        _fix))
+ #else
+-   #define DEPRECATED(_fix) do {} while (0)
++   #define VMW_DEPRECATED(_fix) do {} while (0)
+ #endif
+ 
+ 

--- a/patches/vmhgfs/vmhgfs-uid-gid-kernel-3.12-tools-9.6.1.patch
+++ b/patches/vmhgfs/vmhgfs-uid-gid-kernel-3.12-tools-9.6.1.patch
@@ -128,7 +128,7 @@ diff -ur vmhgfs-only.orig/shared/compat_cred.h vmhgfs-only/shared/compat_cred.h
  #define current_fsgid() (current->fsgid)
  #endif
 
-+#ifdef CONFIG_UIDGID_STRICT_TYPE_CHECKS
++#if defined(CONFIG_UIDGID_STRICT_TYPE_CHECKS) || LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
 +#define CURRENT_FSUID() (__kuid_val(current_fsuid()))
 +#define CURRENT_FSGID() (__kgid_val(current_fsgid()))
 +#define CURRENT_UID() (__kuid_val(current_uid()))


### PR DESCRIPTION
This is a set of patches I used to build and run `vmhgfs` on the Ubuntu 3.18.1 mainline kernel:
```
3.18.1-031801-generic #201412170637 SMP Wed Dec 17 11:38:50 UTC 2014
```
