### PR TITLE
Re-add whitespace from vmblock readlink 3.15 patch

### DIFF
--- a/patches/vmblock/04-vmblock-vfs_readlink-kernel-3.15-tools-9.6.2.patch
+++ b/patches/vmblock/04-vmblock-vfs_readlink-kernel-3.15-tools-9.6.2.patch
@@ -6,10 +6,12 @@ Per: https://github.com/rasa/vmware-tools-patches/issues/9#issue-38077487
 @@ -178,7 +178,11 @@
        return -EINVAL;
     }
-
+ 
 +#if LINUX_VERSION_CODE <= KERNEL_VERSION(3, 14, 99)
     return vfs_readlink(dentry, buffer, buflen, iinfo->name);
 +#else
 +   return readlink_copy(buffer, buflen, iinfo->name);
 +#endif
  }
+ 
+ 


### PR DESCRIPTION
When being copied form the gentoo bug attachment https://507664.bugs.gentoo.org/attachment.cgi?id=374932, it appears that whitespace present in [patches/vmblock/04-vmblock-vfs_readlink-kernel-3.15-tools-9.6.2.patch](https://github.com/rasa/vmware-tools-patches/blob/fe01cb1301a13310c3b32bcd883b4f13ecc35298/patches/vmblock/04-vmblock-vfs_readlink-kernel-3.15-tools-9.6.2.patch) got dropped, making the patch file technically invalid.
- All lines should start with a space, "+", or "-". Line 9 was empty.
- It didn't have enough lines; all lines should start with a space, "+", or "-" (lines 16 and 17 were missing).

(Yes, I know I'm being pedantic since GNU patch accepts the file as-is, despite the missing context lines. Other utilities that work with unified diffs are not as accommodating, and either fail to parse or parse incorrectly because of the errors.)