### PR TITLE
Feature: fix error "no d_alias variable" when install vmware-tools-9.6.2...

### DIFF
--- a/patches/vmhgfs/14-vmhgfs-d_alias-kernel-3.13.0-tools-9.6.2.patch
+++ b/patches/vmhgfs/14-vmhgfs-d_alias-kernel-3.13.0-tools-9.6.2.patch
@@ -1,0 +1,26 @@
+--- vmhgfs-only/inode.c.orig
++++ vmhgfs-only/inode.c
+@@ -1900,7 +1900,11 @@ HgfsPermission(struct inode *inode,
+                            p,
+ #endif
+                            &inode->i_dentry,
++#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 13, 0)
+                            d_alias) {
++#else
++                           d_u.d_alias) {
++#endif
+          int dcount = compat_d_count(dentry);
+          if (dcount) {
+             LOG(4, ("Found %s %d \n", dentry->d_name.name, dcount));
+@@ -1953,7 +1957,11 @@ HgfsPermission(struct inode *inode,
+       /* Find a dentry with valid d_count. Refer bug 587879. */
+       list_for_each(pos, &inode->i_dentry) {
+          int dcount;
++#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 13, 0)
+          struct dentry *dentry = list_entry(pos, struct dentry, d_alias);
++#else
++         struct dentry *dentry = list_entry(pos, struct dentry, d_u.d_alias);
++#endif
+          dcount = compat_d_count(dentry);
+          if (dcount) {
+             LOG(4, ("Found %s %d \n", (dentry)->d_name.name, dcount));


### PR DESCRIPTION
Add new patch to fix the error "no d_alias variable" as follows when install VmwareTools-9.6.2 in kernel 3.13.0:

`
/tmp/modconfig-6c6Zn8/vmhgfs-only/inode.c: In function ‘HgfsPermission’:
/tmp/modconfig-6c6Zn8/vmhgfs-only/inode.c:1898:7: error: ‘struct dentry’ has no member named ‘d_alias’
/tmp/modconfig-6c6Zn8/vmhgfs-only/inode.c:1898:7: warning: initialization from incompatible pointer type [enabled by default]
/tmp/modconfig-6c6Zn8/vmhgfs-only/inode.c:1898:7: error: ‘struct dentry’ has no member named ‘d_alias’
/tmp/modconfig-6c6Zn8/vmhgfs-only/inode.c:1898:7: error: ‘struct dentry’ has no member named ‘d_alias’
/tmp/modconfig-6c6Zn8/vmhgfs-only/inode.c:1898:7: error: ‘struct dentry’ has no member named ‘d_alias’
/tmp/modconfig-6c6Zn8/vmhgfs-only/inode.c:1898:7: error: ‘struct dentry’ has no member named ‘d_alias’
/tmp/modconfig-6c6Zn8/vmhgfs-only/inode.c:1898:7: warning: initialization makes pointer from integer without a cast [enabled by default]
/tmp/modconfig-6c6Zn8/vmhgfs-only/inode.c:1898:7: error: ‘struct dentry’ has no member named ‘d_alias’
`