### PR TITLE
Add 6.0.6 to download-tools.sh

### DIFF
--- a/download-tools.sh
+++ b/download-tools.sh
@@ -12,6 +12,7 @@ https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/7.1.1/2498930/packages/
 https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/7.1.0/2314774/packages/com.vmware.fusion.tools.linux.zip.tar
 https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/7.0.1/2235595/packages/com.vmware.fusion.tools.linux.zip.tar
 https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/7.0.0/2075534/packages/com.vmware.fusion.tools.linux.zip.tar
+https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/6.0.6/2684343/packages/com.vmware.fusion.tools.linux.zip.tar
 https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/6.0.5/2209127/packages/com.vmware.fusion.tools.linux.zip.tar
 https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/6.0.4/1887983/packages/com.vmware.fusion.tools.linux.zip.tar
 https://softwareupdate.vmware.com/cds/vmw-desktop/fusion/6.0.3/1747349/packages/com.vmware.fusion.tools.linux.zip.tar


### PR DESCRIPTION
Could be useful, considering the vmware-tools for 6.0.4 and 6.0.5 contain the same linux.iso.