### PR TITLE
Use --force-install flag to override open-vm-tools check

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -33,6 +33,6 @@ fi
 
 pushd vmware-tools-distrib >/dev/null
 
-  sudo ./vmware-install.pl -d ${VMWARE_INSTALL_OPTIONS}
+sudo ./vmware-install.pl --default --force-install ${VMWARE_INSTALL_OPTIONS}
 
 popd >/dev/null


### PR DESCRIPTION
As far as I can tell, this is essential in the newest version of the tools.. Please correct me if I'm wrong!

Tested this flag with `8.1.0`, `8.0.2`, `7.1.2` & `6.0.1`, so it shouldn't cause any problems.